### PR TITLE
add shortCircuit: true to support node >= 16.17

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ export async function load(sourceUrl, context, defaultLoad) {
   const rawSource = await fs.readFile(filename, 'utf8');
   const result = await transform(rawSource, filename);
 
-  return { format: 'module', source: result };
+  return { format: 'module', source: result, shortCircuit: true };
 }
 
 // Export a jest compatible transform as the default export:


### PR DESCRIPTION
node 16.17 added support for chaining loaders, requiring a loader to either call the next loader or return an object with `shortCircuit: true`.
https://nodejs.org/docs/latest-v16.x/api/esm.html#hooks